### PR TITLE
글자 길이가 24인 경우 동작안하는 오류 수정

### DIFF
--- a/modi_plus/module/output_module/display.py
+++ b/modi_plus/module/output_module/display.py
@@ -197,17 +197,13 @@ class Display(OutputModule):
         """
 
         n = Display.STATE_TEXT_SPLIT_LEN
-        encoding_data = str.encode(str(text))
+        encoding_data = str.encode(str(text)) + bytes(1)
         splited_data = [encoding_data[x - n:x] for x in range(n, len(encoding_data) + n, n)]
         for index, data in enumerate(splited_data):
-            send_data = data
-            if index == len(splited_data) - 1:
-                send_data = send_data + bytes(0)
-
             self._set_property(
                 self._id,
                 Display.PROPERTY_DISPLAY_WRITE_TEXT,
-                property_values=(("bytes", send_data), )
+                property_values=(("bytes", data), )
             )
 
         self._text = text

--- a/tests/module/output_module/test_display.py
+++ b/tests/module/output_module/test_display.py
@@ -28,16 +28,12 @@ class TestDisplay(unittest.TestCase):
         set_messages = []
 
         n = Display.STATE_TEXT_SPLIT_LEN
-        encoding_data = str.encode(mock_text)
+        encoding_data = str.encode(str(mock_text)) + bytes(1)
         splited_data = [encoding_data[x - n:x] for x in range(n, len(encoding_data) + n, n)]
         for index, data in enumerate(splited_data):
-            send_data = data
-            if index == len(splited_data) - 1:
-                send_data = send_data + bytes(0)
-
             set_message = parse_set_property_message(
                 -1, Display.PROPERTY_DISPLAY_WRITE_TEXT,
-                (("bytes", send_data), )
+                (("bytes", data), )
             )
             set_messages.append(set_message)
 


### PR DESCRIPTION
##### - Summary
디스플레이 모듈 write_text 함수에 글자 길이가 24인 경우, 동작 안하는 오류 수정
##### - Related Issues
Close #48 
##### - PR Overview
- [ ] This PR closes one of the issues [y/n] (issue #issue_number_here)
- [ ] This PR requires new unit tests [y/n] (please make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (please make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]


